### PR TITLE
fix: add gh auth check and better error handling for dependabot-pr.sh

### DIFF
--- a/github/cli/scripts/dependabot-pr.sh
+++ b/github/cli/scripts/dependabot-pr.sh
@@ -36,7 +36,18 @@ fi
 
 REPO="$1"
 
-PR_DATA=$(gh pr ls -R "$REPO" -S "author:app/dependabot" --json number,mergeStateStatus --jq '.[]')
+# Check if gh CLI is authenticated
+if ! gh auth status &>/dev/null; then
+  echo "Error: GitHub CLI (gh) is not authenticated." >&2
+  echo "Please run: gh auth login" >&2
+  exit 1
+fi
+
+PR_DATA=$(gh pr ls -R "$REPO" -S "author:app/dependabot" --json number,mergeStateStatus --jq '.[]'2>&1) || {
+  echo "Error: Failed to list PRs for repository '$REPO'." >&2
+  echo "Please check that the repository exists and you have access to it." >&2
+  exit 1
+}
 
 if [[ -z "$PR_DATA" ]]; then
   echo "No dependabot PRs found."

--- a/github/cli/scripts/dependabot-pr.sh
+++ b/github/cli/scripts/dependabot-pr.sh
@@ -43,7 +43,7 @@ if ! gh auth status &>/dev/null; then
   exit 1
 fi
 
-PR_DATA=$(gh pr ls -R "$REPO" -S "author:app/dependabot" --json number,mergeStateStatus --jq '.[]'2>&1) || {
+PR_DATA=$(gh pr ls -R "$REPO" -S "author:app/dependabot" --json number,mergeStateStatus --jq '.[]' 2>&1) || {
   echo "Error: Failed to list PRs for repository '$REPO'." >&2
   echo "Please check that the repository exists and you have access to it." >&2
   exit 1


### PR DESCRIPTION
## What

- Add `gh auth status` check before attempting GitHub API calls
- Add error handler with friendly message when `gh pr ls` fails (401, 403, 404, etc.)
- Prevent script from crashing with raw stderr output

## Why

The script fails silently with unhelpful error messages when gh CLI is not authenticated or lacks permissions. Users get cryptic output like:

```
non-200 OK status code: 401 Unauthorized body: {"message":"Bad credentials"...}
```

Now they get clear guidance:
```
Error: GitHub CLI (gh) is not authenticated.
Please run: gh auth login
```

Fixes #25