### PR TITLE
fix: prevent word splitting in dependabot-pr.sh PR_DATA here-string

### DIFF
--- a/github/cli/scripts/dependabot-pr.sh
+++ b/github/cli/scripts/dependabot-pr.sh
@@ -72,7 +72,7 @@ while read -r pr; do
     BLOCKED_LIST+="- #$number: $status\n"
     ((BLOCKED_COUNT++)) || true
   fi
-done <<< "$PR_DATA"
+done <<<"$PR_DATA"
 
 if [[ $MERGE_COUNT -gt 0 ]]; then
   echo -e "\nMerged: $MERGE_COUNT PR(s)"


### PR DESCRIPTION
## Problem
When running `dependabot-pr.sh` for the first time against a repo with multiple dependabot PRs, all PRs show `UNKNOWN` status instead of their real merge state. A second run works as expected.

## Root cause
Line 75: `done <<< "$PR_DATA"` — the space between `<<<` and the quoted variable causes bash to perform word splitting on the unquoted expansion of `$PR_DATA`. When `PR_DATA` contains newline-separated JSON objects (multiple PRs), only the first word is passed as a here-string, and subsequent `jq` calls on those truncated lines fail silently.

## Fix
Remove the space: `done <<<"$PR_DATA"` so the full variable content is passed as a single here-string without word splitting.